### PR TITLE
Fix typo in Program.cs

### DIFF
--- a/SampleProject/Program.cs
+++ b/SampleProject/Program.cs
@@ -5,7 +5,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddControllersWithViews(options =>
 {
-    // register the action fitter only if we are not in development environment
+    // register the action filter only if we are not in development environment
     if (!builder.Environment.IsDevelopment())
     {
         options.Filters.Add<OriginCheckFilter>();


### PR DESCRIPTION
## Summary
- fix comment to mention "action filter" instead of "action fitter" in `SampleProject/Program.cs`

## Testing
- `dotnet` command not found (so build skipped)